### PR TITLE
Feat: 이미지 타이틀 추가 버튼 구현

### DIFF
--- a/src/components/common/ImageNameButton.js
+++ b/src/components/common/ImageNameButton.js
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+import theme from 'styles/theme';
+
+export const ImageNameButton = ({ inputId, isMultiple }) => {
+  const [imageFileNames, setImageFileNames] = useState([]);
+  const [isAttached, setIsAttached] = useState(false);
+  const [isShow, setIsShow] = useState(true);
+  const inputValue = useRef(null);
+
+  const onLoadImage = useCallback(
+    (e) => {
+      const attachedImageFileName = e.target.files[0].name;
+      setIsAttached(true);
+      setIsShow(true);
+      if (isMultiple)
+        setImageFileNames([...imageFileNames, attachedImageFileName]);
+      else setImageFileNames(attachedImageFileName);
+    },
+    [imageFileNames, isMultiple]
+  );
+
+  const onClickRemoveButton = (e) => {
+    inputValue.current.value = '';
+    setIsShow(false);
+    isMultiple &&
+      setImageFileNames(
+        imageFileNames.filter((name) => name !== e.target.value)
+      );
+  };
+
+  useEffect(() => {
+    console.log(imageFileNames);
+  }, [imageFileNames]);
+
+  return (
+    <Container>
+      <ImageAttachButton htmlFor={inputId}>+ 이미지 첨부</ImageAttachButton>
+      <Input
+        ref={inputValue}
+        type="file"
+        id={inputId}
+        onChange={onLoadImage}
+        multiple={isMultiple}
+      />
+      {isAttached && (
+        <ImageFileNameContainer>
+          {isMultiple ? (
+            imageFileNames.map((e, index) => (
+              <div key={`${e}_${index}`}>
+                <FileName>{e}</FileName>
+                <RemoveButton onClick={onClickRemoveButton} value={e}>
+                  X
+                </RemoveButton>
+              </div>
+            ))
+          ) : (
+            // {isShow}
+            <div>
+              {isShow && (
+                <>
+                  <FileName>{imageFileNames}</FileName>
+                  <RemoveButton
+                    value={imageFileNames}
+                    onClick={onClickRemoveButton}
+                  >
+                    X
+                  </RemoveButton>
+                </>
+              )}
+            </div>
+          )}
+        </ImageFileNameContainer>
+      )}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  margin-left: 20px;
+  display: flex;
+  align-items: flex-start;
+`;
+
+const ImageAttachButton = styled.label`
+  padding: 10px 0;
+  background-color: #fff;
+  border-radius: 5px;
+  border: 1px solid ${theme.colors.mainColor};
+  width: 150px;
+  color: transparent;
+  text-shadow: 0 0 0 black;
+  text-align: center;
+`;
+
+const Input = styled.input`
+  display: none;
+`;
+
+const RemoveButton = styled.button`
+  width: 25px;
+  height: 25px;
+  border-radius: 50%;
+  background-color: #fff;
+  border: 1px solid ${theme.colors.mainColor};
+  color: transparent;
+  text-shadow: 0 0 0 black;
+`;
+
+const FileName = styled.span`
+  margin: 10px 20px;
+  color: transparent;
+  text-shadow: 0 0 0 black;
+  display: inline-block;
+`;
+
+const ImageFileNameContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;

--- a/src/components/common/ImagePreviewButton.js
+++ b/src/components/common/ImagePreviewButton.js
@@ -1,0 +1,87 @@
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+import theme from 'styles/theme';
+
+export const ImagePreviewButton = () => {
+  const [loadedImageSrc, setLoadedImageSrc] = useState('');
+  const inputValue = useRef(null);
+
+  const onLoadImage = (e) => {
+    const file = e.target.files[0];
+    if (!file.type.match('image.*')) {
+      alert('이미지 파일이 아닙니다.');
+      return;
+    }
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    return new Promise((resolve) => {
+      reader.onload = () => {
+        setLoadedImageSrc(reader.result);
+        resolve();
+      };
+    });
+  };
+  const onClickRemoveButton = () => {
+    inputValue.current.value = '';
+    setLoadedImageSrc('');
+  };
+  return (
+    <Container>
+      <ImageAttachButton htmlFor="img">+ 이미지 첨부</ImageAttachButton>
+      <Input ref={inputValue} type="file" id="img" onChange={onLoadImage} />
+      {loadedImageSrc && (
+        <>
+          <ImagePreview src={loadedImageSrc} alt="preview" />
+          <RemoveButton onClick={onClickRemoveButton}>X</RemoveButton>
+        </>
+      )}
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  position: relative;
+  height: 250px;
+  display: flex;
+  border-radius: 5px;
+  justify-content: center;
+  align-items: center;
+  background-color: ${theme.colors.lightPurple};
+`;
+
+const ImageAttachButton = styled.label`
+  padding: 10px 0;
+  background-color: transparent;
+  border-radius: 5px;
+  border: 1px solid ${theme.colors.mainColor};
+  width: 150px;
+  color: transparent;
+  text-shadow: 0 0 0 black;
+  text-align: center;
+`;
+
+const Input = styled.input`
+  display: none;
+`;
+
+const ImagePreview = styled.img`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 100;
+`;
+
+const RemoveButton = styled.button`
+  width: 25px;
+  height: 25px;
+  border-radius: 50%;
+  background-color: #fff;
+  border: 1px solid ${theme.colors.mainColor};
+  color: transparent;
+  text-shadow: 0 0 0 black;
+  z-index: 1000;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+`;


### PR DESCRIPTION
## 📘 작업 유형

- 신규 기능 추가

<br/>

## 📑 작업리스트

> 작업한 목록

- 이미지 추가 버튼 3종류 구현
  - 이미지 타이틀 추가 버튼
  - 다중 이미지 타이틀 추가 버튼
  - 이미지 미리보기 추가 버튼 

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항

- ImageNameButton.js 는 이미지 타이틀 추가 버튼입니다. 버튼 클릭 후 이미지를 업로드하면 해당 이미지의 타이틀과 삭제 버튼이 나타납니다. isMultiple을 props로 받아서 동작하며 true일 경우 이미지를 여러번 업로드 할 시, 타이틀이 계속 추가됩니다. false일 경우 기존의 이미지 타이틀이 변경됩니다.
- ImagePreviewButton.js 는 이미지 미리보기 추가 버튼입니다.
- style은 임의로 넣었습니다. 사용하다가 UI 문제 생기면 얘기해주세요. 직접 수정하고 알려주셔도됩니다.